### PR TITLE
Add trait costs in labels

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -219,6 +219,12 @@
 
     return filtered;
   }
+
+  function getEffectCostsString(trait) {
+    let effectCosts = "(" + trait.effects[0].cost;
+    trait.effects.slice(1).forEach((x) => effectCosts += ` | ${x.cost})`);
+    return effectCosts;
+  }
 </script>
 
 <main>
@@ -256,7 +262,7 @@
             <Input
               type="checkbox"
               checked={isFilteredSet(trait.name)}
-              label="{trait.name} ({trait.effects[0].cost}{trait.effects.slice(1).forEach((x) => ' | {x.cost}')})"
+              label="{trait.name} {getEffectCostsString(trait)}"
               on:change={(e) => {
                 relicSetChange({ trait }, e);
               }}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -256,7 +256,7 @@
             <Input
               type="checkbox"
               checked={isFilteredSet(trait.name)}
-              label={trait.name}
+              label="{trait.name} ({trait.effects[0].cost}{trait.effects.slice(1).forEach((x) => ' | {x.cost}')})"
               on:change={(e) => {
                 relicSetChange({ trait }, e);
               }}


### PR DESCRIPTION
Trait labels should now appear with their costs like "Trailblazer (3)", "Absolute Unit (2 | 3)" etc. for easier identification of how many fragments are required for each trait.

Disclaimer: I'm not a frontend developer and didn't test this code at all lol, but it should be enough to get the idea across. I just think it'd be a useful feature if you're willing to clean up my code :)